### PR TITLE
D-35003 downgrade postgresql.image and rabbitmq.image to original 24.1 versions

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -3255,7 +3255,7 @@ postgresql:
   install: true
   ## @param postgresql.image.tag PostgreSQL image tag (immutable tags are recommended)
   image:
-    tag: 16.1.0-debian-11-r27
+    tag: 15.6.0-debian-12-r7
   ## @param postgresql.hasReport Indicating that reporting database is enabled
   ##
   hasReport: true
@@ -3366,7 +3366,7 @@ rabbitmq:
   install: true
   ## @param rabbitmq.image.tag RabbitMQ image tag (immutable tags are recommended)
   image:
-    tag: 3.13.2-debian-12-r4
+    tag: 3.12.13-debian-12-r2
   ## Clustering settings
   ##
   clustering:


### PR DESCRIPTION
…1 versions